### PR TITLE
use the full path to libSystem.dylib

### DIFF
--- a/src/utils/flock.node.ts
+++ b/src/utils/flock.node.ts
@@ -2,7 +2,7 @@ import koffi from 'npm:koffi@2'
 import * as util from "node:util"
 import host from "./host.ts"
 
-const filename = host().platform == 'darwin' ? 'libSystem.dylib' : 'libc.so.6'
+const filename = host().platform == 'darwin' ? '/usr/lib/libSystem.dylib' : 'libc.so.6'
 const libc = koffi.load(filename)
 
 const LOCK_EX = 2;


### PR DESCRIPTION
it seems dlopen is sensitive to LD_LIBRARY_PATH (even though docs deny this), so in situations where tea invokes itself it can result in the nested tea not being functional.