### PR TITLE
fix external deps

### DIFF
--- a/.github/deno-to-node.ts
+++ b/.github/deno-to-node.ts
@@ -41,7 +41,7 @@ await build({
   },
   importMap: "deno.json",
   mappings: {
-    "https://deno.land/x/is_what@v4.1.8/src/index.ts": "is-what",
+    "https://deno.land/x/is_what@v4.1.13/src/index.ts": "is-what",
     "https://deno.land/x/outdent@v0.8.0/mod.ts": "outdent",
     "./src/utils/flock.deno.ts": "./src/utils/flock.node.ts"
   },

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,33 +15,50 @@ concurrency:
 
 jobs:
   check:
+    if: ${{ github.event.release.prerelease }}
     uses: ./.github/workflows/ci.yml
 
-  build:
+  dnt:
     needs: [check]
-    if: ${{ github.event.release.prerelease }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - [self-hosted, macOS, X64]
+          - ubuntu-latest  # ∵ resilience: PRs verify dnt with this env
+          - [self-hosted, macOS, ARM64]
+          - [self-hosted, linux, ARM64]
     steps:
       - uses: actions/checkout@v3
       - uses: teaxyz/setup@v0
+      - run: deno task dnt ${{ github.event.release.tag_name }}
+
+      - uses: actions/upload-artifact@v3
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        with:
+          path: dist
+
+  publish-npm:
+    needs: [dnt]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v3
 
       # if we don’t do this the npm publish step doesn’t work
       - uses: actions/setup-node@v2
         with:
           registry-url: https://registry.npmjs.org
 
-      - name: build
-        run: .github/deno-to-node.ts ${{ github.event.release.tag_name }}
-
       - run: npm publish --access public
         working-directory: dist
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-  publish:
+  publish-github:
     permissions:
       contents: write
-    needs: [build]
+    needs: [publish-npm]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,17 +24,24 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: teaxyz/setup@v0
-      - run: deno cache $(find . -name \*.ts)
-      - run: deno task test --coverage=cov_profile --no-check
-      # ^^ no check as we have a separate type-checking step and it’s noise here
+      - run: deno cache mod.ts
+
+      - run: deno task test
+          --coverage=cov_profile
+          --no-check # ⬆signal∶noise & ∵ we have `jobs.typecheck`
+
       - run: deno coverage cov_profile --lcov --exclude=tests/ --output=cov_profile.lcov
+        if: ${{ github.event_name != 'workflow_call' }}
+
       - uses: coverallsapp/github-action@v1
+        if: ${{ github.event_name != 'workflow_call' }}
         with:
           path-to-lcov: cov_profile.lcov
           parallel: true
           flag-name: ${{ matrix.platform.id }}
 
   upload-coverage:
+    if: ${{ github.event_name != 'workflow_call' }}
     needs: tests
     runs-on: ubuntu-latest
     steps:
@@ -42,16 +49,20 @@ jobs:
       with:
         parallel-finished: true
 
+  verify-usage-as-deno-lib:
+    # we’re checking no import-map type imports snuck in
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'workflow_call' }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          path: src
+      - uses: denoland/setup-deno@v1
+      - run: deno run --no-config --unstable src/mod.ts
+
   dnt:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - [self-hosted, macOS, X64]
-          - [self-hosted, linux, X64]
-          - [self-hosted, macOS, ARM64]
-          - [self-hosted, linux, ARM64]
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'workflow_call' }}
     steps:
       - uses: actions/checkout@v3
       - uses: teaxyz/setup@v0

--- a/deno.json
+++ b/deno.json
@@ -29,7 +29,6 @@
   },
   "imports": {
     "is-what": "https://deno.land/x/is_what@v4.1.8/src/index.ts",
-    "outdent": "https://deno.land/x/outdent@v0.8.0/mod.ts",
     "deno/": "https://deno.land/std@0.189.0/"
   }
 }

--- a/mod.ts
+++ b/mod.ts
@@ -1,12 +1,13 @@
-import host from "./src/utils/host.ts"
-import SemVer, * as semver from "./src/utils/semver.ts"
-import Path from "./src/utils/Path.ts"
-export * as types from "./src/types.ts"
-
 import "./src/utils/misc.ts"
 import { flatmap, validate } from "./src/utils/misc.ts"
 
+import host from "./src/utils/host.ts"
+import SemVer, * as semver from "./src/utils/semver.ts"
+import Path from "./src/utils/Path.ts"
+
+export * as types from "./src/types.ts"
 import * as pkg from "./src/utils/pkg.ts"
+
 import TeaError, { panic } from "./src/utils/error.ts"
 import useConfig from "./src/hooks/useConfig.ts"
 import useOffLicense  from "./src/hooks/useOffLicense.ts"

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,0 +1,22 @@
+import * as is_what from "https://deno.land/x/is_what@v4.1.13/src/index.ts"
+export { is_what }
+
+import { type PlainObject } from "https://deno.land/x/is_what@v4.1.13/src/index.ts"
+export type { PlainObject }
+
+import * as outdent from "https://deno.land/x/outdent@v0.8.0/mod.ts"
+export { outdent }
+
+// importing super specifically to reduce final npm bundle size
+import * as crypto from "https://deno.land/std@0.190.0/crypto/mod.ts"
+import { moveSync } from "https://deno.land/std@0.190.0/fs/move.ts"
+import { readLines } from "https://deno.land/std@0.190.0/io/read_lines.ts"
+import { writeAll } from "https://deno.land/std@0.190.0/streams/write_all.ts"
+import { parse as parseYaml } from "https://deno.land/std@0.190.0/yaml/parse.ts"
+
+const streams = { writeAll }
+const io = { readLines }
+const fs = { moveSync }
+const deno = { readLines, crypto, fs, io, streams, parseYaml }
+
+export { deno }

--- a/src/hooks/useConfig.ts
+++ b/src/hooks/useConfig.ts
@@ -1,5 +1,5 @@
+import { flatmap } from "../utils/misc.ts"
 import host from "../utils/host.ts"
-import { flatmap } from "../utils/misc.ts";
 import Path from "../utils/Path.ts"
 
 export interface Config {

--- a/src/hooks/useDownload.ts
+++ b/src/hooks/useDownload.ts
@@ -1,5 +1,6 @@
-import { crypto, toHashString } from "deno/crypto/mod.ts"
-import { writeAll } from "deno/streams/write_all.ts"
+import { deno } from "../deps.ts"
+const { crypto: crypto_, streams: { writeAll } } = deno
+const { toHashString, crypto } = crypto_
 import TeaError, { panic } from "../utils/error.ts"
 import useConfig from "./useConfig.ts"
 import useFetch from "./useFetch.ts"

--- a/src/hooks/usePantry.ts
+++ b/src/hooks/usePantry.ts
@@ -1,4 +1,5 @@
-import { isNumber, isPlainObject, isString, isArray, isPrimitive, PlainObject, isBoolean } from "is-what"
+import { is_what, PlainObject } from "../deps.ts"
+const { isNumber, isPlainObject, isString, isArray, isPrimitive, isBoolean } = is_what
 import { validatePackageRequirement } from "../utils/hacks.ts"
 import { Package, Installation } from "../types.ts"
 import useMoustaches from "./useMoustaches.ts"

--- a/src/hooks/useSync.ts
+++ b/src/hooks/useSync.ts
@@ -1,6 +1,7 @@
 // deno-lint-ignore-file no-deprecated-deno-api
 // ^^ Deno.Command is not implemented for dnt shims yet
-import { writeAll } from "deno/streams/write_all.ts"
+import { deno } from "../deps.ts"
+const { streams: { writeAll } } = deno
 import { flock } from "../utils/flock.deno.ts"
 import useDownload from "./useDownload.ts"
 import usePantry from "./usePantry.ts"

--- a/src/plumbing/hydrate.ts
+++ b/src/plumbing/hydrate.ts
@@ -1,7 +1,8 @@
 import { PackageRequirement, Package } from "../types.ts"
 import * as semver from "../utils/semver.ts"
 import usePantry from "../hooks/usePantry.ts"
-import { isArray } from "is-what"
+import { is_what } from "../deps.ts"
+const { isArray } = is_what
 
 
 //TODO linktime cyclic dependencies cannot be allowed

--- a/src/plumbing/install.ts
+++ b/src/plumbing/install.ts
@@ -4,7 +4,8 @@
 import { createHash } from "https://deno.land/std@0.177.0/node/crypto.ts"
 import { Package, Installation, StowageNativeBottle } from "../types.ts"
 import useOffLicense from "../hooks/useOffLicense.ts"
-import { writeAll } from "deno/streams/write_all.ts"
+import { deno } from "../deps.ts"
+const { streams: { writeAll } } = deno
 import useDownload from "../hooks/useDownload.ts"
 import useConfig from "../hooks/useConfig.ts"
 import useCellar from "../hooks/useCellar.ts"

--- a/src/porcelain/install.ts
+++ b/src/porcelain/install.ts
@@ -6,7 +6,8 @@ import hydrate from "../plumbing/hydrate.ts"
 import useSync from "../hooks/useSync.ts"
 import { parse } from "../utils/pkg.ts"
 import link from "../plumbing/link.ts"
-import { isString } from "is-what"
+import { is_what } from "../deps.ts"
+const { isString } = is_what
 
 export interface Logger extends InstallLogger {
   resolved?(resolution: Resolution): void

--- a/src/porcelain/run.ts
+++ b/src/porcelain/run.ts
@@ -8,7 +8,8 @@ import useSync from "../hooks/useSync.ts"
 import which from "../plumbing/which.ts"
 import link from "../plumbing/link.ts"
 import Path from "../utils/Path.ts"
-import { isArray } from "is-what"
+import { is_what } from "../deps.ts"
+const { isArray } = is_what
 
 interface OptsEx {
   env?: Record<string, string | undefined>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
+import host, { SupportedPlatform, SupportedArchitecture } from "./utils/host.ts"
 import SemVer, { Range } from "./utils/semver.ts"
 import Path from "./utils/Path.ts"
-import host from "./utils/host.ts"
 
 export interface Package {
   project: string
@@ -18,14 +18,6 @@ export interface Installation {
   path: Path
   pkg: Package
 }
-
-// when we support more variants of these that require specification
-// we will tuple a version in with each eg. 'darwin' | ['windows', 10 | 11 | '*']
-export const SupportedPlatforms = ["darwin" , "linux" , "windows"] as const
-export type SupportedPlatform = typeof SupportedPlatforms[number]
-
-export const SupportedArchitectures = ["x86-64", "aarch64"] as const
-export type SupportedArchitecture = typeof SupportedArchitectures[number]
 
 /// remotely available package content (bottles or source tarball)
 export type Stowage = {

--- a/src/utils/Path.ts
+++ b/src/utils/Path.ts
@@ -1,12 +1,11 @@
-import { parse as parseYaml } from "https://deno.land/std@0.182.0/encoding/yaml.ts"
-import { readLines } from "deno/io/read_lines.ts"
-import * as sys from "deno/path/mod.ts"
-import { PlainObject } from "is-what"
-import * as fs from "deno/fs/mod.ts"
+import { deno, PlainObject } from "../deps.ts"
 import { mkdtempSync } from "node:fs"
+import * as sys from "node:path"
 import * as os from "node:os"
 
-// based on https://github.com/mxcl/Path.swift
+const { io: { readLines }, fs, parseYaml } = deno
+
+// modeled after https://github.com/mxcl/Path.swift
 
 // everything is Sync because TypeScript will unfortunately not
 // cascade `await`, meaning our chainable syntax would become:
@@ -339,7 +338,7 @@ export default class Path {
   async readYAML(): Promise<unknown> {
     try {
       const txt = await this.read()
-      return parseYaml(txt)
+      return parseYaml(txt, { filename: this.string /*improves err msgs*/ })
     } catch (err) {
       err.cause = this.string
       throw err

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,6 +1,7 @@
-import { PlainObject, isPlainObject, isRegExp, isString } from "is-what"
+import { is_what, outdent, PlainObject } from "../deps.ts"
+const { isPlainObject, isRegExp, isString } = is_what
+const undent = outdent.default
 import * as pkg from "./pkg.ts"
-import undent from "outdent"
 
 type ID =
   'not-found: tea -X: arg0' |

--- a/src/utils/hacks.ts
+++ b/src/utils/hacks.ts
@@ -1,5 +1,6 @@
 import { PackageRequirement } from "../types.ts"
-import { isString, isNumber } from "is-what"
+import { is_what } from "../deps.ts"
+const { isString, isNumber } = is_what
 import * as semver from "./semver.ts"
 import host from "./host.ts"
 

--- a/src/utils/host.test.ts
+++ b/src/utils/host.test.ts
@@ -1,6 +1,5 @@
 import { assert, assertEquals, assertThrows, fail } from "deno/testing/asserts.ts"
-import { SupportedPlatform } from "../types.ts"
-import host, { _internals } from "./host.ts"
+import host, { _internals, SupportedPlatform } from "./host.ts"
 import { stub } from "deno/testing/mock.ts"
 
 Deno.test("host()", async () => {

--- a/src/utils/host.ts
+++ b/src/utils/host.ts
@@ -1,5 +1,12 @@
-import { SupportedPlatform, SupportedArchitecture } from "../types.ts"
 import process from "node:process"
+
+// when we support more variants of these that require specification
+// we will tuple a version in with each eg. 'darwin' | ['windows', 10 | 11 | '*']
+export const SupportedPlatforms = ["darwin" , "linux" , "windows"] as const
+export type SupportedPlatform = typeof SupportedPlatforms[number]
+
+export const SupportedArchitectures = ["x86-64", "aarch64"] as const
+export type SupportedArchitecture = typeof SupportedArchitectures[number]
 
 interface HostReturnValue {
   platform: SupportedPlatform

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -1,6 +1,7 @@
 //CONTRACT you can’t use anything from hooks
 
-import { isPlainObject, isArray, PlainObject } from "is-what"
+import { is_what, PlainObject } from "../deps.ts"
+const { isPlainObject, isArray } = is_what
 
 function validate_str(input: unknown): string {
   if (typeof input == 'boolean') return input ? 'true' : 'false'

--- a/src/utils/semver.ts
+++ b/src/utils/semver.ts
@@ -1,4 +1,5 @@
-import { isArray, isString } from "is-what"
+import { is_what } from "../deps.ts"
+const { isArray, isString } = is_what
 
 /**
  * we have our own implementation because open source is full of weird


### PR DESCRIPTION
This isn't exactly pretty, but it fixes this problem:
```shell
echo 'import * as tea from "https://raw.github.com/teaxyz/lib/v0.3.0/mod.ts"' >foo.ts && deno check --unstable foo.ts
error: Relative import path "is-what" not prefixed with / or ./ or ../
    at https://raw.githubusercontent.com/teaxyz/lib/v0.3.0/src/utils/semver.ts:1:35

echo 'import * as tea from "../tea/lib/mod.ts"' >foo.ts && deno check --unstable foo.ts
Check file:///Users/jacob/foo/foo.ts
```

Basically, import maps don't externalize, meaning any consumer needs to provide our deps... that part seems deeply incorrect.