### PR TITLE
allow `usePantry().project()` to use `display-name:`

### DIFF
--- a/src/hooks/usePantry.test.ts
+++ b/src/hooks/usePantry.test.ts
@@ -49,7 +49,7 @@ Deno.test("runtime.env", async () => {
 })
 
 Deno.test("project by display-name", async () => {
-  const agpt = usePantry().project("Auto-GPT")
-  assert(await agpt.available())
-  assertMatch((await agpt.yaml()).versions.github, /Significant-Gravitas\/Auto-GPT/)
+  const aws = usePantry().project("aws/cli")
+  assert(await aws.available())
+  assertMatch((await aws.yaml()).versions.github, /aws\/aws-cli\/tags/)
 })

--- a/src/hooks/usePantry.test.ts
+++ b/src/hooks/usePantry.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "deno/testing/asserts.ts"
+import { assert, assertEquals, assertMatch } from "deno/testing/asserts.ts"
 import { useTestConfig } from "./useTestConfig.ts"
 import { _internals } from "../utils/host.ts"
 import { stub } from "deno/testing/mock.ts"
@@ -46,4 +46,10 @@ Deno.test("runtime.env", async () => {
   assertEquals(env.BAZ, prefix.join("bar.com/v1.2.3/baz").string)
 
   _config_internals.reset()
+})
+
+Deno.test("project by display-name", async () => {
+  const agpt = usePantry().project("Auto-GPT")
+  assert(await agpt.available())
+  assertMatch((await agpt.yaml()).versions.github, /Significant-Gravitas\/Auto-GPT/)
 })

--- a/src/hooks/usePantry.ts
+++ b/src/hooks/usePantry.ts
@@ -81,6 +81,10 @@ export default function usePantry() {
         // We didn't find project... but maybe it's a display-name?
         for await (const entry of ls()) {
           const filename = entry.path
+          // from about here on, we're not very DRY with the
+          // above code, but it's not worth the effort to
+          // refactor it, unless we love this and want to use
+          // it.
           if (!filename.exists()) continue
 
           const yml = await filename.readYAML()
@@ -134,6 +138,8 @@ export default function usePantry() {
       })
     }
 
+    // FIXME: doesn't rely on `yaml()`, so this is the only
+    // function that doesn't work on display-name alone.
     const provider = async () => {
       for (const prefix of pantry_paths()) {
         if (!prefix.exists()) continue


### PR DESCRIPTION
This is going to be controversial. However, since _everything_ under `project()` uses `yaml()` (except `provider()` which should get some love), we can do the lookup in one place.

- it involves walking the pantries, which will get awful over time
- it slows down failures to find packages
- but it should allow people to use display-names with tea: `tea +Auto-GPT sh`
- ~there's a little duplication in `yaml()` that could be factored out~ handled

I don't know who wants this or why, but it _seems_ like it could be a good idea.

ETA: one of the benefits here is that is means less of a research task to move from the GUI to the command-line (for named packages). The disconnect still exists for packages who have their URIs trimmed, but one thing at a time.

ETA2: obviously, just like searching the provides or anything else that walks the pantries, this can be sped up by making `useSync` write out some metadata rollup to `sqlite`.

ETA3: we don't currently have any providers with display-names. But it shouldn't be hard. You'd just either duplicate the walk check, or make `project()` itself async so it can do the scan when its called. either seemed out of scope at this time.