### PR TITLE
Fixed a dead link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ const go = await install("go.dev");
 
 ### Designed for Composibility
 
-The library is split into [plumbing] and [porcelain] (copying git’s lead).
+The library is split into [plumbing](src/plumbing) and [porcelain](src/porcelain) (copying git’s lead).
 The porcelain is what most people need, but if you need more control, dive
 into the porcelain sources to see how to use the plumbing primitives to get
 precisely what you need.


### PR DESCRIPTION
Not sure if the links are correctly updated, but ATM they point to a 404 page.